### PR TITLE
Handle 403 errors

### DIFF
--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -16,7 +16,7 @@ from logging import getLogger
 
 from flask import abort, request
 from flask_appbuilder.security.manager import AUTH_REMOTE_USER
-from flask_appbuilder.security.views import AuthView
+from flask_appbuilder.security.views import AuthView, expose
 from flask_login import current_user, login_user
 from jwcrypto import jwk, jws, jwt
 
@@ -276,8 +276,10 @@ class AirflowAstroSecurityManager(AstroSecurityManagerMixin, AirflowSecurityMana
 
 class AuthAstroJWTView(AuthView):
     """
-    Replace the default RemoteUser view with one that doesn't add anything
-
-    We don't want any views for this user type.
+    If a user does not have permission, they are automatically rediected
+    to the login function of this class. Since we handle everything externally
+    we make this look more like an actual 403 error.
     """
-    pass
+    @expose("/access-denied/")
+    def login(self):
+        return abort(403)

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -279,6 +279,8 @@ class AuthAstroJWTView(AuthView):
     If a user does not have permission, they are automatically rediected
     to the login function of this class. Since we handle everything externally
     we make this look more like an actual 403 error.
+
+    Reference to FAB: https://github.com/dpgaspar/Flask-AppBuilder/blob/fd8e323fcd59ec4b28df91e12915eeebdf293060/flask_appbuilder/security/decorators.py#L134
     """
     @expose("/access-denied/")
     def login(self):


### PR DESCRIPTION
This PR allows us to handle 403 errors with our system, rather than 302ing to /login in airflow, since that won't really work in our environment.