### PR TITLE
Save JWT-created user to DB

### DIFF
--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -181,6 +181,7 @@ class AstroSecurityManagerMixin(object):
                 self.manage_user_roles(user, claims['roles'])
 
             self.get_session.merge(user)
+            self.get_session.commit()
             if not login_user(user):
                 raise RuntimeError("Error logging user in!")
 

--- a/tests/astronomer/flask_appbuilder/test_security.py
+++ b/tests/astronomer/flask_appbuilder/test_security.py
@@ -94,6 +94,8 @@ class TestAstroSecurityManagerMixin:
         assert g.user.is_anonymous is False
         assert ['Op'] == [r.name for r in g.user.roles]
 
+        assert appbuilder.sm.find_user(username=valid_claims['sub']) == g.user
+
         # Ensure that we actually wrote to the DB
         appbuilder.session.refresh(g.user)
 


### PR DESCRIPTION
Without committing this session the User object we created was not
saved, meaning that we would create a new on every time (which wasn't
what I intenteded) - this was visible by seeing the "Creating airflow
user details for ... from JWT" appear once per request in the logs.

This fixes that problem, and also means the user can edit their name now