### PR TITLE
Get tests running with Airflow 1.10.10

### DIFF
--- a/tests/astronomer/flask_appbuilder/conftest.py
+++ b/tests/astronomer/flask_appbuilder/conftest.py
@@ -34,6 +34,12 @@ def db(app, sm_class):
 @pytest.fixture(scope='module')
 def appbuilder(app, db, sm_class):
     from flask_appbuilder import AppBuilder
+    from flask_appbuilder.forms import FieldConverter
+   
+    # Un-monkey patch airflow
+    FieldConverter.conversion_table = (
+        (fn, field, widget) for fn,field,widget in FieldConverter.conversion_table if fn != 'is_utcdatetime'
+    )
 
     appbuilder = AppBuilder(app, db.session, security_manager_class=sm_class)
 

--- a/tests/astronomer/flask_appbuilder/conftest.py
+++ b/tests/astronomer/flask_appbuilder/conftest.py
@@ -35,10 +35,10 @@ def db(app, sm_class):
 def appbuilder(app, db, sm_class):
     from flask_appbuilder import AppBuilder
     from flask_appbuilder.forms import FieldConverter
-   
+
     # Un-monkey patch airflow
     FieldConverter.conversion_table = (
-        (fn, field, widget) for fn,field,widget in FieldConverter.conversion_table if fn != 'is_utcdatetime'
+        (fn, field, widget) for fn, field, widget in FieldConverter.conversion_table if fn != 'is_utcdatetime'
     )
 
     appbuilder = AppBuilder(app, db.session, security_manager_class=sm_class)

--- a/tests/astronomer/flask_appbuilder/test_security.py
+++ b/tests/astronomer/flask_appbuilder/test_security.py
@@ -9,6 +9,8 @@ import pytest
 from astronomer.flask_appbuilder.security import AirflowAstroSecurityManager
 
 AUDIENCE = 'airflow.example.com'
+
+
 @pytest.fixture(scope='session')
 def allowed_audience():
     return AUDIENCE


### PR DESCRIPTION
My monkey patching in Airflow for timezone support broke "stock" FAB when airflow is imported, not the CustomSQLAInterface of Airflow isn't being used.