### PR TITLE
Add current user backend

### DIFF
--- a/src/astronomer/flask_appbuilder/current_user_backend.py
+++ b/src/astronomer/flask_appbuilder/current_user_backend.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Basic authentication backend"""
+"""Auth backend that uses current user value set by authentication proxy."""
 from functools import wraps
 from typing import Callable, Optional, Tuple, TypeVar, Union, cast
 
 from flask import Response
-from flask_login import current_user, login_user
+from flask_login import current_user
 from requests.auth import AuthBase
 
 CLIENT_AUTH: Optional[Union[Tuple[str, str], AuthBase]] = None

--- a/src/astronomer/flask_appbuilder/current_user_backend.py
+++ b/src/astronomer/flask_appbuilder/current_user_backend.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Auth backend that uses current user value set by authentication proxy."""
 from functools import wraps
-from typing import Callable, Optional, Tuple, TypeVar, Union, cast
+from typing import Callable, cast, Optional, Tuple, TypeVar, Union
 
 from flask import Response
 from flask_login import current_user

--- a/src/astronomer/flask_appbuilder/proxy_auth_backend.py
+++ b/src/astronomer/flask_appbuilder/proxy_auth_backend.py
@@ -1,0 +1,46 @@
+# Copyright 2019 Astronomer Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Basic authentication backend"""
+from functools import wraps
+from typing import Callable, Optional, Tuple, TypeVar, Union, cast
+
+from flask import Response
+from flask_login import current_user, login_user
+from requests.auth import AuthBase
+
+CLIENT_AUTH: Optional[Union[Tuple[str, str], AuthBase]] = None
+
+
+def init_app(_):
+    """Initializes authentication backend"""
+
+
+T = TypeVar("T", bound=Callable)  # pylint: disable=invalid-name
+
+
+def requires_authentication(function: T):
+    """Decorator for functions that require authentication"""
+
+    if not current_user.is_anonymous:
+        return current_user
+
+    @wraps(function)
+    def decorated(*args, **kwargs):
+        if not current_user.is_anonymous:
+            login_user(current_user, remember=False)
+            return function(*args, **kwargs)
+
+        return Response("Unauthorized", 401, {"WWW-Authenticate": "Basic"})
+
+    return cast(T, decorated)

--- a/src/astronomer/flask_appbuilder/proxy_auth_backend.py
+++ b/src/astronomer/flask_appbuilder/proxy_auth_backend.py
@@ -32,9 +32,6 @@ T = TypeVar("T", bound=Callable)  # pylint: disable=invalid-name
 def requires_authentication(function: T):
     """Decorator for functions that require authentication"""
 
-    if not current_user.is_anonymous:
-        return current_user
-
     @wraps(function)
     def decorated(*args, **kwargs):
         if not current_user.is_anonymous:

--- a/src/astronomer/flask_appbuilder/proxy_auth_backend.py
+++ b/src/astronomer/flask_appbuilder/proxy_auth_backend.py
@@ -35,7 +35,6 @@ def requires_authentication(function: T):
     @wraps(function)
     def decorated(*args, **kwargs):
         if not current_user.is_anonymous:
-            login_user(current_user, remember=False)
             return function(*args, **kwargs)
 
         return Response("Unauthorized", 401, {"WWW-Authenticate": "Basic"})

--- a/tests/astronomer/flask_appbuilder/conftest.py
+++ b/tests/astronomer/flask_appbuilder/conftest.py
@@ -2,15 +2,16 @@ import os
 import time
 import uuid
 
-import pytest
-from astronomer.flask_appbuilder import current_user_backend
-from astronomer.flask_appbuilder.security import AstroSecurityManagerMixin
+import flask_appbuilder
 from jwcrypto import jwk, jwt
+import pytest
 from sqlalchemy import event
 
-import flask_appbuilder
+from astronomer.flask_appbuilder import current_user_backend
+from astronomer.flask_appbuilder.security import AstroSecurityManagerMixin
 
 AUDIENCE = 'airflow.example.com'
+
 
 @pytest.fixture(scope='module')
 def app():
@@ -163,7 +164,6 @@ def role(appbuilder):
         return role
 
     return role_factory
-
 
 
 @pytest.fixture(scope='session')

--- a/tests/astronomer/flask_appbuilder/conftest.py
+++ b/tests/astronomer/flask_appbuilder/conftest.py
@@ -5,8 +5,8 @@ from jwcrypto import jwk
 import pytest
 from sqlalchemy import event
 
+from astronomer.flask_appbuilder import current_user_backend
 from astronomer.flask_appbuilder.security import AstroSecurityManagerMixin
-
 
 @pytest.fixture(scope='module')
 def app():
@@ -18,7 +18,11 @@ def app():
     app.config['SECRET_KEY'] = 'thisismyscretkey'
     app.config['TESTING'] = True
 
+    app.api_auth = current_user_backend
+    app.api_auth.init_app(app)
+
     @app.route("/")
+    @current_user_backend.requires_authentication
     def home():
         return "Hello"
     return app

--- a/tests/astronomer/flask_appbuilder/test_current_user_backend.py
+++ b/tests/astronomer/flask_appbuilder/test_current_user_backend.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import url_for
+
+
+@pytest.mark.usefixtures("client_class", "run_in_transaction")
+class TestCurrentUserBackend:
+    def test_allow_current_user(
+        self, signed_jwt, valid_claims
+    ):
+        jwt = signed_jwt(valid_claims)
+        resp = self.client.get(
+            url_for("home"), headers=[("Authorization", "Bearer " + jwt)]
+        )
+        assert resp.status_code == 200
+
+    @patch("astronomer.flask_appbuilder.security.login_user")    
+    def test_reject_anonymous_user(
+        self, login_user, signed_jwt, valid_claims
+    ):
+        login_user = MagicMock(return_value=True)
+        jwt = signed_jwt(valid_claims)
+        resp = self.client.get(
+            url_for("home"), headers=[("Authorization", "Bearer " + jwt)]
+        )
+        assert resp.status_code == 401

--- a/tests/astronomer/flask_appbuilder/test_current_user_backend.py
+++ b/tests/astronomer/flask_appbuilder/test_current_user_backend.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
 from flask import url_for
+import pytest
 
 
 @pytest.mark.usefixtures("client_class", "run_in_transaction")
@@ -15,11 +15,13 @@ class TestCurrentUserBackend:
         )
         assert resp.status_code == 200
 
-    @patch("astronomer.flask_appbuilder.security.login_user")    
+    @patch("astronomer.flask_appbuilder.security.login_user")
     def test_reject_anonymous_user(
         self, login_user, signed_jwt, valid_claims
     ):
-        login_user = MagicMock(return_value=True)
+        login_user = MagicMock()
+        login_user.return_value = True
+
         jwt = signed_jwt(valid_claims)
         resp = self.client.get(
             url_for("home"), headers=[("Authorization", "Bearer " + jwt)]

--- a/tests/astronomer/flask_appbuilder/test_security.py
+++ b/tests/astronomer/flask_appbuilder/test_security.py
@@ -1,12 +1,11 @@
 import os
 import time
-import uuid
 
-import pytest
-from astronomer.flask_appbuilder.security import AirflowAstroSecurityManager
 from flask import g, url_for
-from jwcrypto import jwk, jwt
+import pytest
 from tests.astronomer.flask_appbuilder.conftest import AUDIENCE
+
+from astronomer.flask_appbuilder.security import AirflowAstroSecurityManager
 
 
 @pytest.mark.usefixtures('client_class', 'run_in_transaction')

--- a/tests/astronomer/flask_appbuilder/test_security.py
+++ b/tests/astronomer/flask_appbuilder/test_security.py
@@ -2,55 +2,11 @@ import os
 import time
 import uuid
 
+import pytest
+from astronomer.flask_appbuilder.security import AirflowAstroSecurityManager
 from flask import g, url_for
 from jwcrypto import jwk, jwt
-import pytest
-
-from astronomer.flask_appbuilder.security import AirflowAstroSecurityManager
-
-AUDIENCE = 'airflow.example.com'
-
-
-@pytest.fixture(scope='session')
-def allowed_audience():
-    return AUDIENCE
-
-
-@pytest.fixture
-def invalid_jwt():
-    ephemeral_key = jwk.JWK(generate='oct', size=64)
-    token = jwt.JWT(header={"alg": "HS256"}, claims={"info": "I'm a signed token"})
-    token.make_signed_token(ephemeral_key)
-    return token.serialize()
-
-
-@pytest.fixture
-def signed_jwt(jwt_signing_key):
-    def jwt_factory(claims):
-        token = jwt.JWT(header={"alg": "HS256"}, claims=claims)
-        token.make_signed_token(jwt_signing_key)
-        return token.serialize()
-    return jwt_factory
-
-
-@pytest.fixture
-def valid_claims(request):
-
-    return {
-        'email': 'airflower@domain.com',
-        'roles': ['Op'],
-        'sub': str(uuid.uuid4()),
-        'full_name': 'Lucy Airflower',
-        'aud': AUDIENCE,
-        'nbf': int(time.time()),
-        'exp': int(time.time()) + 60,
-    }
-
-
-@pytest.fixture
-def airflow_config(jwt_signing_cert, monkeypatch, allowed_audience):
-    monkeypatch.setitem(os.environ, 'AIRFLOW__ASTRONOMER__JWT_SIGNING_CERT', jwt_signing_cert)
-    monkeypatch.setitem(os.environ, 'AIRFLOW__ASTRONOMER__JWT_AUDIENCE', allowed_audience)
+from tests.astronomer.flask_appbuilder.conftest import AUDIENCE
 
 
 @pytest.mark.usefixtures('client_class', 'run_in_transaction')


### PR DESCRIPTION
This adds a new authentication backend that exclusively checks the `current_user` value. This works when the Astro platform uses the `before_request` method in the security manager to decode a JWT and populate the `current_user` value.

To specify this backend in production, add this line to your dockerfile.

`ENV AIRFLOW__API__AUTH_BACKEND=astronomer.flask_appbuilder.current_user_backend`