### PR TITLE
Use different context with same user token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
           name: Deploy to GCS Bucket
           # Even though there is a project field in the JSON credential, gsutil still needs a project set, so lets set pull it from it
           command: |-
+            export GOOGLE_APPLICATION_CREDENTIALS_CONTENT="${GCP_TOKEN}"
             pip-release-utilities/gsutil-auth-helper.sh
             gsutil -m rsync -a public-read /tmp/workspace/dist/ gs://<< pipeline.parameters.deploy_bucket >>/simple/astronomer-fab-security-manager
       - run:
@@ -106,4 +107,3 @@ jobs:
       - store_artifacts:
           path: /tmp/workspace/dist/
           destination: dist
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
             tags:
               only: /.*/
       - publish:
-          context: "Pip Deploy"
+          context: "gcp-astronomer-prod"
           requires: [build]
           # Run this stage only for version-number tagged builds
           filters:


### PR DESCRIPTION
I found two contexts that have the same user token, so I'm using the other one instead.

Alternatively I can just update this token in CircleCI and we can close this PR.