### PR TITLE
Release 1.6.0 - redirect user to astronomer when role misalignment detected

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'apache-airflow>=1.10.0',
         # FAB is pulled in from Airflow
         'jwcrypto~=0.6.0',
+        'requests',
     ],
     setup_requires=[
         'pytest-runner~=4.0',

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -15,7 +15,7 @@ import json
 from logging import getLogger
 import os
 
-from flask import abort, request, session, redirect
+from flask import abort, redirect, request, session
 from flask_appbuilder.security.manager import AUTH_REMOTE_USER
 from flask_appbuilder.security.views import AuthView, expose
 from flask_login import current_user, login_user, logout_user

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -34,7 +34,7 @@ except ImportError:
         EXISTING_ROLES = []
 
 
-__version__ = "1.6.0"
+__version__ = "1.5.0"
 
 log = getLogger(__name__)
 

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -193,7 +193,7 @@ class AstroSecurityManagerMixin(object):
             if set(session_roles) != set(claim_roles):
                 logout_user()
                 flash('Your permission set has changed. You have been redirected to the Airflow homepage with your new permission set.')
-                return redirect(url_for('Airflow.index'))
+                return redirect(url_for('IndexView.index'))
 
         super().before_request()
 

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -186,10 +186,7 @@ class AstroSecurityManagerMixin(object):
             self.get_session.commit()
             if not login_user(user):
                 raise RuntimeError("Error logging user in!")
-            role_names = []
-            for role in user.roles:
-                role_names.append(role.name)
-            session["roles"] = role_names
+            session["roles"] = claims['roles']
         else:
             session_roles = session['roles']
             claim_roles = claims['roles']

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -34,7 +34,7 @@ except ImportError:
         EXISTING_ROLES = []
 
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 log = getLogger(__name__)
 

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -15,7 +15,7 @@ import json
 from logging import getLogger
 import os
 
-from flask import abort, redirect, request, session
+from flask import abort, flash, redirect, request, session, url_for
 from flask_appbuilder.security.manager import AUTH_REMOTE_USER
 from flask_appbuilder.security.views import AuthView, expose
 from flask_login import current_user, login_user, logout_user
@@ -34,7 +34,7 @@ except ImportError:
         EXISTING_ROLES = []
 
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 log = getLogger(__name__)
 
@@ -192,7 +192,8 @@ class AstroSecurityManagerMixin(object):
             claim_roles = claims['roles']
             if set(session_roles) != set(claim_roles):
                 logout_user()
-                return redirect('/')
+                flash('Your permission set has changed. You have been redirected to the Airflow homepage with your new permission set.')
+                return redirect(url_for('Airflow.index'))
 
         super().before_request()
 

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -117,7 +117,6 @@ class AstroSecurityManagerMixin(object):
         updated to match the claims. Otherwise a new user record will be
         created.
         """
-        print("TESTING Custom fab-sec-manager install into image 3")
         if request.path == '/health':
             return super().before_request()
 


### PR DESCRIPTION
## Description

Logout and redirect user to airflow homepage when there is a discrepency between what astronomer thinks the user's permissions are and what the flask session thinks the users permissions are.

## 🎟 Issue(s)

Resolves astronomer/issues#3053

## 🧪 Functional Testing

Test 1:
    1. Log two users into astronomer in separate browsers. One user should be system admin(S1) , the other a workspace admin (U1) with admin permissions on a deployment D1
    2. navigate the workspace admin to the airflow UI of D1
    3. from S1's screen downgrade U1's role to be a viewer on D1
    4. click on an admin only link within U1's screen within the airflow UI of D1 such as viewing or editing variables
    5. U1 should be redirected to airflow homepage UI they will see decreased permissions

## 📸 Screenshots

![demo640pxLowRoles](https://user-images.githubusercontent.com/8050013/121440815-7ea71800-c93d-11eb-86f7-e9ed4bb64f25.gif)



