### PR TITLE
Fix link to security.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ easiest way of setting this is via environment variables prefixed with
 `AIRFLOW__ASTRONOMER__`
 
 For a list of current settings check out the inline documentation in
-[security.py](astronomer/flask_appbuilder/security.py)
+[security.py](src/astronomer/flask_appbuilder/security.py)
 
 ## Development
 


### PR DESCRIPTION
This PR is just a simple typo fix for the `README.md` so the link to `security.py` points to the proper location.