### PR TITLE
Save user authentication stats for easier access

### DIFF
--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import functools
 import json
 from logging import getLogger
@@ -220,6 +221,15 @@ class AstroSecurityManagerMixin(object):
                 user.last_name = ''
                 user.active = True
                 self.manage_user_roles(user, claims['roles'])
+
+            # Similar to the upstream FAB security managers, update
+            # authentication stats so user admins can view them without
+            # having to dig through webserver logs
+            if not user.login_count:
+                user.login_count = 0
+            user.login_count += 1
+            user.last_login = datetime.datetime.now()
+            user.fail_login_count = 0
 
             self.get_session.add(user)
             self.get_session.commit()


### PR DESCRIPTION
When users authenticate via JWTs, we should save call the `update_user_auth_stat` so the `login_count`, `failed_login_count`, and `last_login` columns are updated in the database, and therefore viewable in the web UI.

Without this, users have to dig through webserver logs to find user authentications, which is more painful.

This is copied from [Flask-Appbuilder](https://github.com/dpgaspar/Flask-AppBuilder/blob/c59b4136d6036d53ff1af33e14385b5a86121b7a/flask_appbuilder/security/manager.py#L830). I believe that the code cannot call `BaseSecurityManager.update_user_auth_stat` directly since that method calls `BaseSecurityManager.update_user(user)`, which commits to the database and our tests rely on the code being tested to not do that. If there's a better way to implement this, please let me know.