### PR TITLE
Bugfix: Houston URL timeout needs to be an int

### DIFF
--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -385,7 +385,7 @@ class AirflowAstroSecurityManager(AstroSecurityManagerMixin, AirflowSecurityMana
         httprequest = Request(
             houston_url, method="GET", headers={"Accept": "application/json"}
         )
-        houston_url_timeout = conf.get("astronomer", "houston_url_timeout", fallback=10)
+        houston_url_timeout = conf.getfloat("astronomer", "houston_url_timeout", fallback=10.0)
         with urlopen(httprequest, timeout=houston_url_timeout) as response:
             key = response.read().decode()
         return jwk.JWK.from_json(key=key)


### PR DESCRIPTION
Without this change:

```
Waiting for host: advanced-axis-8406-pgbouncer.astronomer-advanced-axis-8406 6543
[2022-01-18 12:13:35,644] {security.py:363} INFO - Loading Astronomer JWT from houston jwk
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/airflow/__main__.py", line 40, in main
    args.func(args)
  File "/usr/local/lib/python3.7/site-packages/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/cli.py", line 91, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/airflow/cli/commands/sync_perm_command.py", line 26, in sync_perm
    appbuilder = cached_app().appbuilder  # pylint: disable=no-member
  File "/usr/local/lib/python3.7/site-packages/airflow/www/app.py", line 146, in cached_app
    app = create_app(config=config, testing=testing)
  File "/usr/local/lib/python3.7/site-packages/airflow/www/app.py", line 123, in create_app
    init_appbuilder(flask_app)
  File "/usr/local/lib/python3.7/site-packages/airflow/www/extensions/init_appbuilder.py", line 51, in init_appbuilder
    update_perms=conf.getboolean('webserver', 'UPDATE_FAB_PERMS'),
  File "/usr/local/lib/python3.7/site-packages/flask_appbuilder/base.py", line 148, in __init__
    self.init_app(app, session)
  File "/usr/local/lib/python3.7/site-packages/flask_appbuilder/base.py", line 202, in init_app
    self.sm = self.security_manager_class(self)
  File "/usr/local/lib/python3.7/site-packages/astronomer/flask_appbuilder/security.py", line 337, in __init__
    self.reload_jwt_signing_cert()
  File "/usr/local/lib/python3.7/site-packages/astronomer/flask_appbuilder/security.py", line 364, in reload_jwt_signing_cert
    self.jwt_signing_cert = self._get_jwt_key_from_houston()
  File "/usr/local/lib/python3.7/site-packages/astronomer/flask_appbuilder/security.py", line 69, in wrapped_f
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/astronomer/flask_appbuilder/security.py", line 389, in _get_jwt_key_from_houston
    with urlopen(httprequest, timeout=houston_url_timeout) as response:
  File "/usr/local/lib/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/lib/python3.7/urllib/request.py", line 525, in open
    response = self._open(req, data)
  File "/usr/local/lib/python3.7/urllib/request.py", line 543, in _open
    '_open', req)
  File "/usr/local/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python3.7/urllib/request.py", line 1393, in https_open
    context=self._context, check_hostname=self._check_hostname)
  File "/usr/local/lib/python3.7/urllib/request.py", line 1350, in do_open
    encode_chunked=req.has_header('Transfer-encoding'))
  File "/usr/local/lib/python3.7/http/client.py", line 1281, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/lib/python3.7/http/client.py", line 1327, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.7/http/client.py", line 1276, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.7/http/client.py", line 1036, in _send_output
    self.send(msg)
  File "/usr/local/lib/python3.7/http/client.py", line 976, in send
    self.connect()
  File "/usr/local/lib/python3.7/http/client.py", line 1443, in connect
    super().connect()
  File "/usr/local/lib/python3.7/http/client.py", line 948, in connect
    (self.host,self.port), self.timeout, self.source_address)
  File "/usr/local/lib/python3.7/socket.py", line 713, in create_connection
    sock.settimeout(timeout)
TypeError: an integer is required (got type str)
```