### PR TITLE
Fix `houston_url_timeout` to be an int

### DIFF
--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -385,7 +385,7 @@ class AirflowAstroSecurityManager(AstroSecurityManagerMixin, AirflowSecurityMana
         httprequest = Request(
             houston_url, method="GET", headers={"Accept": "application/json"}
         )
-        houston_url_timeout = conf.get("astronomer", "houston_url_timeout", fallback=10)
+        houston_url_timeout = conf.getint("astronomer", "houston_url_timeout", fallback=10)
         with urlopen(httprequest, timeout=houston_url_timeout) as response:
             key = response.read().decode()
         return jwk.JWK.from_json(key=key)


### PR DESCRIPTION
Right now it causes this traceback:


```
[2022-01-18 15:49:18,751[] {security.py:363} INFO - Loading Astronomer JWT from houston jwk
Traceback (most recent call last):
...
  File "/usr/local/lib/python3.9/site-packages/astronomer/flask_appbuilder/security.py", line 389, in _get_jwt_key_from_houston
    with urlopen(httprequest, timeout=houston_url_timeout) as response:
...
  File "/usr/local/lib/python3.9/socket.py", line 829, in create_connection
    sock.settimeout(timeout)
TypeError: an integer is required (got type str)
```