### PR TITLE
add URLError to the list of errors caught by _get_jwt_key_from_houston

### DIFF
--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -17,7 +17,7 @@ import json
 from logging import getLogger
 import os
 from time import monotonic_ns
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from airflow.exceptions import AirflowConfigException
@@ -368,7 +368,7 @@ class AirflowAstroSecurityManager(AstroSecurityManagerMixin, AirflowSecurityMana
         try:
             log.info("Loading Astronomer JWT from houston jwk")
             self.jwt_signing_cert = self._get_jwt_key_from_houston()
-        except (AirflowConfigException, HTTPError):
+        except (AirflowConfigException, HTTPError, URLError):
             stat = os.stat(self.jwt_signing_cert_path)
             if stat.st_mtime_ns > self.jwt_signing_cert_mtime:
                 log.info(


### PR DESCRIPTION
Current versions of Enterprise are crash-looping when astronomer-tls is signed by a private CA because recent verisons of FAB are trying to fetch the URL but the private CA's are not propagated out to the airflow namespace in Enterprise nor the webserver container.

There is ALREADY logic to catch failed http requests and fall back to the in-namespace JWK but it's failing because URLError isn't one the list of error types it explicitly catches. This adds it and I expect would cause it to work.

This is ENTIRELY untested, but raising this PR for visibility as per jed's suggestion.

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/airflow/__main__.py", line 48, in main
    args.func(args)
  File "/usr/local/lib/python3.9/site-packages/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/utils/cli.py", line 92, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/cli/commands/sync_perm_command.py", line 26, in sync_perm
    appbuilder = cached_app().appbuilder
  File "/usr/local/lib/python3.9/site-packages/airflow/www/app.py", line 147, in cached_app
    app = create_app(config=config, testing=testing)
  File "/usr/local/lib/python3.9/site-packages/airflow/www/app.py", line 124, in create_app
    init_appbuilder(flask_app)
  File "/usr/local/lib/python3.9/site-packages/airflow/www/extensions/init_appbuilder.py", line 46, in init_appbuilder
    AirflowAppBuilder(
  File "/usr/local/lib/python3.9/site-packages/flask_appbuilder/base.py", line 148, in __init__
    self.init_app(app, session)
  File "/usr/local/lib/python3.9/site-packages/flask_appbuilder/base.py", line 202, in init_app
    self.sm = self.security_manager_class(self)
  File "/usr/local/lib/python3.9/site-packages/astronomer/flask_appbuilder/security.py", line 337, in __init__
    self.reload_jwt_signing_cert()
  File "/usr/local/lib/python3.9/site-packages/astronomer/flask_appbuilder/security.py", line 364, in reload_jwt_signing_cert
    self.jwt_signing_cert = self._get_jwt_key_from_houston()
  File "/usr/local/lib/python3.9/site-packages/astronomer/flask_appbuilder/security.py", line 69, in wrapped_f
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/astronomer/flask_appbuilder/security.py", line 389, in _get_jwt_key_from_houston
    with urlopen(httprequest, timeout=houston_url_timeout) as response:
  File "/usr/local/lib/python3.9/urllib/request.py", line 214, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/lib/python3.9/urllib/request.py", line 523, in open
    response = meth(req, response)
  File "/usr/local/lib/python3.9/urllib/request.py", line 632, in http_response
    response = self.parent.error(
  File "/usr/local/lib/python3.9/urllib/request.py", line 555, in error
    result = self._call_chain(*args)
  File "/usr/local/lib/python3.9/urllib/request.py", line 494, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python3.9/urllib/request.py", line 747, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/local/lib/python3.9/urllib/request.py", line 517, in open
    response = self._open(req, data)
  File "/usr/local/lib/python3.9/urllib/request.py", line 534, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/local/lib/python3.9/urllib/request.py", line 494, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python3.9/urllib/request.py", line 1389, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
  File "/usr/local/lib/python3.9/urllib/request.py", line 1349, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)>
```