### PR TITLE
Update to better method names and add compatibility shim for older Airflows

### DIFF
--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -20,6 +20,7 @@ from time import monotonic_ns
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+import airflow
 from airflow.exceptions import AirflowConfigException
 from flask import abort, flash, redirect, request, session, url_for
 from flask_appbuilder.security.manager import AUTH_REMOTE_USER
@@ -44,6 +45,8 @@ except ImportError:
 __version__ = "1.8.4"
 
 log = getLogger(__name__)
+
+AIRFLOW_VERSION_TUPLE = tuple(map(int, airflow.__version__.split('.')[:3]))
 
 
 def timed_lru_cache(
@@ -300,7 +303,14 @@ class AstroSecurityManagerMixin(object):
         pass
 
 
-class AirflowAstroSecurityManager(AstroSecurityManagerMixin, AirflowSecurityManager):
+Airflow23CompatibilityMixin = object
+# Only define this if we're using an old version of Airflow
+if AIRFLOW_VERSION_TUPLE < (2, 3):
+    class Airflow23CompatibilityMixin:
+        pass
+
+
+class AirflowAstroSecurityManager(AstroSecurityManagerMixin, AirflowSecurityManager, Airflow23CompatibilityMixin):
     """
     This class configures the FAB SecurityManager for use in Airflow, and reads
     settings under the ``[astronomer]`` section (or environment variables prefixed

--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -326,6 +326,18 @@ if AIRFLOW_VERSION_TUPLE < (2, 3):
             """
             return self.find_permission_view_menu(action_name, resource_name)
 
+        def add_permission_to_role(self, role, permission):
+            """
+            Add an existing permission pair to a role.
+            :param role: The role about to get a new permission.
+            :type role: Role
+            :param permission: The permission pair to add to a role.
+            :type permission: PermissionView
+            :return: None
+            :rtype: None
+            """
+            self.add_permission_role(role, permission)
+
 
 class AirflowAstroSecurityManager(AstroSecurityManagerMixin, AirflowSecurityManager, Airflow23CompatibilityMixin):
     """
@@ -440,22 +452,22 @@ class AirflowAstroSecurityManager(AstroSecurityManagerMixin, AirflowSecurityMana
             if not perm:
                 continue
 
-            self.add_permission_role(self.find_role("User"), perm)
-            self.add_permission_role(self.find_role("Op"), perm)
-            self.add_permission_role(self.find_role("Viewer"), perm)
+            self.add_permission_to_role(self.find_role("User"), perm)
+            self.add_permission_to_role(self.find_role("Op"), perm)
+            self.add_permission_to_role(self.find_role("Viewer"), perm)
 
         for (view_menu, permission) in [
                 ('Airflow', 'can_dagrun_success'),
                 ('Airflow', 'can_dagrun_failed'),
                 ('Airflow', 'can_failed'),
         ]:
-            self.add_permission_role(self.find_role("User"), self.get_permission(permission, view_menu))
-            self.add_permission_role(self.find_role("Op"), self.get_permission(permission, view_menu))
+            self.add_permission_to_role(self.find_role("User"), self.get_permission(permission, view_menu))
+            self.add_permission_to_role(self.find_role("Op"), self.get_permission(permission, view_menu))
 
         for (view_menu, permission) in [
                 ('VariableModelView', 'varexport'),
         ]:
-            self.add_permission_role(self.find_role("Op"), self.get_permission(permission, view_menu))
+            self.add_permission_to_role(self.find_role("Op"), self.get_permission(permission, view_menu))
 
 
 class AuthAstroJWTView(AuthView):


### PR DESCRIPTION
This PR switches to using the updated method names from apache/airflow#18726, and adds a compatibility shim mixin to the `AirflowAstroSecurityManager` to ensure that it works for both Airflow 2.3.0 and later, and Airflow 2.2.x and below.

Only the methods that are actually used are in the compatibility shim, although I included some links to assist anybody who needs to add similar shims in the future.