### PR TITLE
Fix has_access() to pass on unrecognized kwargs like 'user'

### DIFF
--- a/src/astronomer/flask_appbuilder/security.py
+++ b/src/astronomer/flask_appbuilder/security.py
@@ -294,10 +294,10 @@ class AstroSecurityManagerMixin(object):
         permissions.RESOURCE_USER
         permissions.ACTION_CAN_CREATE
 
-        def has_access(self, action_name, resource_name) -> bool:
+        def has_access(self, action_name, resource_name, **kwargs) -> bool:
             if action_name == permissions.ACTION_CAN_CREATE and resource_name == permissions.RESOURCE_USER:
                 return False
-            return super().has_access(action_name, resource_name)
+            return super().has_access(action_name, resource_name, **kwargs)
 
     except (ImportError, AttributeError):
         pass


### PR DESCRIPTION
This PR fixes `has_access` to pass on keyword arguments to `super().has_access()`, since the `user` keyword argument was [added to Airflow's vendored/customized FAB security manager](https://github.com/apache/airflow/blob/7d97ee5b3a41e412d63b34433adec5672adb1011/airflow/www/security.py#L349).